### PR TITLE
Add fall training events to osg-htc site

### DIFF
--- a/2025-08-12-chtc-at-terrace.md
+++ b/2025-08-12-chtc-at-terrace.md
@@ -35,6 +35,8 @@ sidebar: |
     If you have any questions about the event, email us at [chtc@cs.wisc.edu](mailto:chtc@cs.wisc.edu)
 ---
 
+***⚠️ This event is canceled due to weather and staffing outages.***
+
 **Join CHTC facilitators at the Memorial Union Terrace!**
 
 Summers in Madison mean summers at the terrace! Trade your indoor office for the outdoors and join CHTC facilitators at the Memorial Union Terrace! 

--- a/2025-09-16-jupyter.md
+++ b/2025-09-16-jupyter.md
@@ -6,6 +6,7 @@ start_date: 2025-09-16
 end_date: 2025-09-16
 publish_on:
   - osg
+tags: osg-training
 
 excerpt:
     Sign up for our user training!

--- a/2025-09-16-jupyter.md
+++ b/2025-09-16-jupyter.md
@@ -1,0 +1,49 @@
+---
+title: "OSPool User Training - Get Started on the OSPool with Jupyter Hub"
+short_title: "Get Started on the OSPool with Jupyter Hub"
+published: true
+start_date: 2025-09-16
+end_date: 2025-09-16
+publish_on:
+  - osg
+
+excerpt:
+    Sign up for our user training!
+
+image:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+banner:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+
+sidebar: |
+    # Who
+
+    New and prospective OSPool users who want to learn about using Jupyter Hub to access OSPool resources.
+
+    # When
+
+    Tuesday, September 16 from 2:30-4:00pm EST
+
+    # Where
+
+    Virtual
+
+    # Questions?
+
+    We provide ongoing support via email at <support@osg-htc.org>, and it’s never a bad idea to start by sending questions or issues via email. You can typically expect a first response within a few business hours.
+---
+
+<p style="font-size: larger; font-weight: bold;">Sign Up for our September 16 training!</p>
+
+Are you new to the OSPool? This short workshop will help you get started on the OSPool through the Jupyter Hub interface. We’ll introduce and explore the interface, submit HTCondor jobs, and discuss workflows suitable for this resource. An OSPool account is not required for this training.
+
+### Prerequisites
+* Some familiarity with shell commands, such as how to edit files, copy/paste in the terminal
+* Optional: OSPool account on AP40
+
+<a class="btn btn-secondary me-md-2 text-dark" href="https://osgfacilitation.setmore.com/class-session/e019b354-8c9b-4a66-916c-78a11241fda2" role="button">Register here</a> <a class="btn btn-secondary me-md-2 text-dark" href="/services/facilitation/monthly-training" role="button">Other upcoming trainings</a>
+<br><br>
+
+All User Training sessions are offered from 2:30-4:00pm EST on the third Tuesday of the month. It's best to already have an active OSPool account to follow along with hands-on examples, but anyone can listen in by registering.

--- a/2025-10-21-ospool-basics.md
+++ b/2025-10-21-ospool-basics.md
@@ -11,10 +11,10 @@ excerpt:
     Sign up for our user training!
 
 image:
-    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/20240308_Morgridge_RCFs.jpg"
     alt: "OSPool User Training"
 banner:
-    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/20240308_Morgridge_RCFs.jpg"
     alt: "OSPool User Training"
 
 sidebar: |

--- a/2025-10-21-ospool-basics.md
+++ b/2025-10-21-ospool-basics.md
@@ -1,0 +1,49 @@
+---
+title: "OSPool User Training - OSPool Basics: Scaling Your Research with High Throughput Computing"
+short_title: "OSPool Basics: Scaling Your Research with High Throughput Computing"
+published: true
+start_date: 2025-10-21
+end_date: 2025-10-21
+publish_on:
+  - osg
+
+excerpt:
+    Sign up for our user training!
+
+image:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+banner:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+
+sidebar: |
+    # Who
+
+    New and prospective OSPool users who want to learn about using Jupyter Hub to access OSPool resources.
+
+    # When
+
+    Tuesday, October 21 from 2:30-4:00pm EST
+
+    # Where
+
+    Virtual
+
+    # Questions?
+
+    We provide ongoing support via email at <support@osg-htc.org>, and it’s never a bad idea to start by sending questions or issues via email. You can typically expect a first response within a few business hours.
+---
+
+<p style="font-size: larger; font-weight: bold;">Sign up for our training!</p>
+
+Learn how to scale your research using the OSPool, a high throughput computing (HTC) resource for running large numbers of computational jobs. This training will introduce the fundamentals of HTC, guide you through getting started on the OSPool, and include a hands-on walkthrough where you'll submit and manage your own jobs. Ideal for researchers who want to scale their analyses efficiently and new/prospective OSPool users.
+
+### Prerequisites
+* Some familiarity with shell commands, such as how to edit files, copy/paste in the terminal
+* Recommended: OSPool account
+
+<a class="btn btn-secondary me-md-2 text-dark" href="https://booking.setmore.com/scheduleappointment/9e81c695-e735-4ddc-93b9-9e9e7e1eb215/session/c0b787ad-a3f3-42da-85c1-7fccfb6dcfde" role="button">Register here</a> <a class="btn btn-secondary me-md-2 text-dark" href="/services/facilitation/monthly-training" role="button">Other upcoming trainings</a>
+<br><br>
+
+All User Training sessions are offered from 2:30-4:00pm EST on the third Tuesday of the month. It's best to already have an active OSPool account to follow along with hands-on examples, but anyone can listen in by registering.

--- a/2025-10-21-ospool-basics.md
+++ b/2025-10-21-ospool-basics.md
@@ -6,6 +6,7 @@ start_date: 2025-10-21
 end_date: 2025-10-21
 publish_on:
   - osg
+tags: osg-training
 
 excerpt:
     Sign up for our user training!

--- a/2025-11-18-python-ospool.md
+++ b/2025-11-18-python-ospool.md
@@ -6,6 +6,7 @@ start_date: 2025-11-18
 end_date: 2025-11-18
 publish_on:
   - osg
+tags: osg-training
 
 excerpt:
     Sign up for our user training!

--- a/2025-11-18-python-ospool.md
+++ b/2025-11-18-python-ospool.md
@@ -1,0 +1,50 @@
+---
+title: "OSPool User Training - Deploying Python Programs on the OSPool"
+short_title: "Deploying Python Programs on the OSPool"
+published: true
+start_date: 2025-11-18
+end_date: 2025-11-18
+publish_on:
+  - osg
+
+excerpt:
+    Sign up for our user training!
+
+image:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+banner:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+
+sidebar: |
+    # Who
+
+    New and prospective OSPool users who want to learn about using Jupyter Hub to access OSPool resources.
+
+    # When
+
+    Tuesday, November 18 from 2:30-4:00pm EST
+
+    # Where
+
+    Virtual
+
+    # Questions?
+
+    We provide ongoing support via email at <support@osg-htc.org>, and it’s never a bad idea to start by sending questions or issues via email. You can typically expect a first response within a few business hours.
+---
+
+<p style="font-size: larger; font-weight: bold;">Sign up for our training!</p>
+
+Many programs used by researchers are written in Python. In this training, you'll learn how to set up and use Python in the OSPool. We'll start with how to deploy a consistent software environment, primarily through the use of containers. We'll also cover how to use Conda for managing and deploying Python environments. Then we'll cover how to set up your execution script for running Python jobs. Finally, we'll discuss the practical considerations for adapting your Python programs to a high throughput computing system.
+
+### Prerequisites
+* Some familiarity with shell commands, such as how to edit files, copy/paste in the terminal
+* Some familiarity with Python
+* Recommended: OSPool account
+
+<a class="btn btn-secondary me-md-2 text-dark" href="https://booking.setmore.com/scheduleappointment/9e81c695-e735-4ddc-93b9-9e9e7e1eb215/session/3d73ecea-a0a3-46e3-b7ba-4e0a0757eda6" role="button">Register here (Opens 8/18)</a> <a class="btn btn-secondary me-md-2 text-dark" href="/services/facilitation/monthly-training" role="button">Other upcoming trainings</a>
+<br><br>
+
+All User Training sessions are offered from 2:30-4:00pm EST on the third Tuesday of the month. It's best to already have an active OSPool account to follow along with hands-on examples, but anyone can listen in by registering.

--- a/2025-11-18-python-ospool.md
+++ b/2025-11-18-python-ospool.md
@@ -11,10 +11,10 @@ excerpt:
     Sign up for our user training!
 
 image:
-    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/christina-instructing.jpg"
     alt: "OSPool User Training"
 banner:
-    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/christina-instructing.jpg"
     alt: "OSPool User Training"
 
 sidebar: |

--- a/2025-12-16-hardware-ospool.md
+++ b/2025-12-16-hardware-ospool.md
@@ -6,6 +6,7 @@ start_date: 2025-12-16
 end_date: 2025-12-16
 publish_on:
   - osg
+tags: osg-training
 
 excerpt:
     Sign up for our user training!

--- a/2025-12-16-hardware-ospool.md
+++ b/2025-12-16-hardware-ospool.md
@@ -1,0 +1,50 @@
+---
+title: "OSPool User Training - Choosing the Right Hardware on the OSG OSPool: ARM64, x86_64 microarcs, and GPUs"
+short_title: "Choosing the Right Hardware on the OSG OSPool: ARM64, x86_64 microarcs, and GPUs"
+published: true
+start_date: 2025-12-16
+end_date: 2025-12-16
+publish_on:
+  - osg
+
+excerpt:
+    Sign up for our user training!
+
+image:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+banner:
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    alt: "OSPool User Training"
+
+sidebar: |
+    # Who
+
+    New and prospective OSPool users who want to learn about using Jupyter Hub to access OSPool resources.
+
+    # When
+
+    Tuesday, December 16 from 2:30-4:00pm EST
+
+    # Where
+
+    Virtual
+
+    # Questions?
+
+    We provide ongoing support via email at <support@osg-htc.org>, and it’s never a bad idea to start by sending questions or issues via email. You can typically expect a first response within a few business hours.
+---
+
+<p style="font-size: larger; font-weight: bold;">Sign up for our training!</p>
+
+The OSG OSPool provides access to a diverse set of compute resources with varying CPU architectures and specialized hardware like ARM64 and GPUs. This short training introduces researchers to the key differences between ARM64, x86_64 and  x86_64 microarchitectures, discusses how to build and run portable software across them, and outlines considerations for targeting GPU-enabled resources. Attendees will learn how to request specific hardware types in their jobs, optimize for performance and compatibility, and ensure their jobs take full advantage of the available heterogeneity in the OSPool.
+
+### Prerequisites
+* Familiarity with shell commands, such as how to edit files, copy/paste in the terminal
+* Some familiarity with using and building containers
+* Recommended: OSPool account
+
+<a class="btn btn-secondary me-md-2 text-dark" href="https://booking.setmore.com/scheduleappointment/9e81c695-e735-4ddc-93b9-9e9e7e1eb215/session/4086ed9a-eff7-4839-92f5-3fc036aa1a69" role="button">Register here (Opens 9/16)</a> <a class="btn btn-secondary me-md-2 text-dark" href="/services/facilitation/monthly-training" role="button">Other upcoming trainings</a>
+<br><br>
+
+All User Training sessions are offered from 2:30-4:00pm EST on the third Tuesday of the month. It's best to already have an active OSPool account to follow along with hands-on examples, but anyone can listen in by registering.

--- a/2025-12-16-hardware-ospool.md
+++ b/2025-12-16-hardware-ospool.md
@@ -1,6 +1,6 @@
 ---
-title: "OSPool User Training - Choosing the Right Hardware on the OSG OSPool: ARM64, x86_64 microarcs, and GPUs"
-short_title: "Choosing the Right Hardware on the OSG OSPool: ARM64, x86_64 microarcs, and GPUs"
+title: "OSPool User Training - Choosing the Right Hardware on the OSG OSPool: ARM64, x86_64 microarchs, and GPUs"
+short_title: "Choosing the Right Hardware on the OSG OSPool: ARM64, x86_64 microarchs, and GPUs"
 published: true
 start_date: 2025-12-16
 end_date: 2025-12-16

--- a/2025-12-16-hardware-ospool.md
+++ b/2025-12-16-hardware-ospool.md
@@ -11,10 +11,10 @@ excerpt:
     Sign up for our user training!
 
 image:
-    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/HPC-cluster.jpg"
     alt: "OSPool User Training"
 banner:
-    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/showmic-helping.jpg"
+    path: "https://raw.githubusercontent.com/CHTC/Events/main/images/HPC-cluster.jpg"
     alt: "OSPool User Training"
 
 sidebar: |


### PR DESCRIPTION
Added 4 training pages. I've also added `tags: osg-training` to them so that they will show up when https://github.com/osg-htc/osg-htc.github.io/pull/420 is merged.